### PR TITLE
fix: 修复新数据源替换旧数据源时引发断言的问题

### DIFF
--- a/JYSlideSegmentController/Source/JYSlideSegmentController.m
+++ b/JYSlideSegmentController/Source/JYSlideSegmentController.m
@@ -700,6 +700,10 @@ shouldRecognizeSimultaneouslyWithGestureRecognizer:
     if (collectionView == self.segmentBar) {
         return;
     }
+    /* 在更换数据源viewControllers时候，若新数据源数量 < 老数据源数量，会触发方法viewControllerAtIndex的断言。 */
+    if (self.viewControllers.count <= indexPath.row) {
+        return;
+    }
     
     UIViewController *previousViewController = [self viewControllerAtIndex:indexPath.row];
     if (previousViewController == nil) {


### PR DESCRIPTION
在更换数据源viewControllers时候，若新数据源数量 < 老数据源数量，会触发方法viewControllerAtIndex的断言。